### PR TITLE
Teleport: If group name is not empty, then add it

### DIFF
--- a/teleport-inventory.py
+++ b/teleport-inventory.py
@@ -100,8 +100,8 @@ def main():
             # If a label is an ansible variable, omit it from groups
             if k.startswith("ansible_"):
                 continue
-
-            _group_add(group_name=v, hostname=hostname)
+            if v != '':
+                _group_add(group_name=v, hostname=hostname)
 
     print(json.dumps(INVENTORY, indent=4))
 


### PR DESCRIPTION
Check if the Value of a group is not null or not empty, then add it.
This was failing with groups that were simply not defined `''`